### PR TITLE
Add fix to allow exiting with Control-c and add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+crackcoin/*.pyc
+*.db

--- a/crackcoin.py
+++ b/crackcoin.py
@@ -7,13 +7,14 @@ import crackcoin.transactions
 
 
 commands = {'q':'quit', 'h':'help', 'b':'broadcast', 't':'transaction', 'i':'information'}
+running = True
 
 if __name__ == "__main__":
 
 	crackcoin.network.startNetworking()
 	crackcoin.miner.startMining()
 	
-	while True:
+	while running:
 
 		try:
 		
@@ -36,6 +37,11 @@ if __name__ == "__main__":
 
 			if ui == 'b':
 				crackcoin.network.broadcastSync()
+
+		except KeyboardInterrupt:
+			print "Exiting ..."
+			running = False
+			break
 				
 		except Exception as e:
 			print "Exception in main: " + e.message


### PR DESCRIPTION
Fix common problem: While loop keeps running but does not allow input when Control-c is pressed. Commit adds variable, running = true, instead of while true. Then it adds a exception handler for keyboard interrupt. .gitignore file is also added excluding *.pyc and crackcoin.db file.